### PR TITLE
Update to version 0.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *_1000.fa*
-NC_012920.fa
+NC_012920.fa*
 NC_012920.fa_1000_elongated
 .snakemake
+resources/contamMix
 *.jar

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ snakemake -s mitoBench_pipeline.Snakefile \
           --cluster 'qsub -pe smp {threads} -l virtual_free={cluster.vfree},h_vmem={cluster.hvmem},class={cluster.class} -o {cluster.out} -e {cluster.err}' \
           --use-conda \
           --local-cores 8 \
-          --cores 100
+          --jobs 100
 ```
 
 If some of these parameters are not available or not feasible for your local

--- a/mitoBench_pipeline-SGE.json
+++ b/mitoBench_pipeline-SGE.json
@@ -63,25 +63,6 @@
         "class"  : "default"
     },
 
-    "trim_bam" :
-    {
-        "vfree"  : "3G",
-        "hvmem"  : "3G"
-    },
-
-    "angsd_consensus" :
-    {
-        "vfree"  : "3G",
-        "hvmem"  : "3G"
-    },
-
-
-    "angsd_consensus_unclipped" :
-    {
-        "vfree"  : "3G",
-        "hvmem"  : "3G"
-    },
-
     "haplogrep2" :
     {
         "vfree"  : "10G",

--- a/mitoBench_pipeline-SLURM.json
+++ b/mitoBench_pipeline-SLURM.json
@@ -71,28 +71,6 @@
         "time"      : "1-00:00"
     },
 
-    "trim_bam" :
-    {
-        "mem"       : "3K",
-        "partition" : "short",
-        "time"      : "0-02:00"
-    },
-
-    "angsd_consensus" :
-    {
-        "mem"       : "3K",
-        "partition" : "short",
-        "time"      : "0-02:00"
-    },
-
-
-    "angsd_consensus_unclipped" :
-    {
-        "mem"       : "3K",
-        "partition" : "short",
-        "time"      : "0-02:00"
-    },
-
     "haplogrep2" :
     {
         "mem"       : "10K",

--- a/resources/snpAD-0.3.3/vcf2fasta.pl
+++ b/resources/snpAD-0.3.3/vcf2fasta.pl
@@ -21,9 +21,8 @@ while (<STDIN>) {
 
 	my @alleles = ( $ref ) ;
 	@alleles = ( $ref, split ",", $alt ) if ( $alt ne "." ) ;
-#	print "$chrom $pos $alleles[0] $alleles[1] $info{GT}\n" ;
 	
-	if ($info{DP} ge 3 & $qual ge 50) {
+	if ($info{DP} >= 3 & $qual >= 50) {
         if ( $info{GT} eq "0/0" ) { substr( $seq, $pos-1, 1 ) = $alleles[0] ; }
         elsif ( $info{GT} eq "1/1" ) { substr( $seq, $pos-1, 1 ) = $alleles[1] ; }
         elsif ( $info{GT} eq "0/1" ) { 


### PR DESCRIPTION
This commit replaces all things that were based on ANGSD with snpAD
(final consensus, haplogroup determination, contamination estimate using
contamMix). ANGSD is not included in the pipeline any longer.

Additional changes:
- filter reads for minimal read length of 30 and mapping quality of 25
- require a minimum read depth 3 and a genotype quality of 50 in order
to call genoytpe based on the snpAD genotype likelihoods.
- bugfixes